### PR TITLE
Fix bug with _ANY Flag value. It's supposed to be 0 not 8.

### DIFF
--- a/types.go
+++ b/types.go
@@ -102,7 +102,9 @@ const (
 	// _BPF_PROG_GET_FD_BY_ID
 	// _BPF_MAP_GET_FD_BY_ID
 	// _BPF_OBJ_GET_INFO_BY_FD
+)
 
+const (
 	_Any = iota
 	_NoExist
 	_Exist


### PR DESCRIPTION
Without this map.Put() sets flag = 8 and bpf sysclal returns with EINVAL.