### PR TITLE
stop hiding pointers behind uint64 in *Attr structs

### DIFF
--- a/map.go
+++ b/map.go
@@ -57,8 +57,8 @@ func (m Map) GetRaw(key encoding.BinaryMarshaler, value *[]byte) (bool, error) {
 	_, e := bpfCall(_MapLookupElem,
 		unsafe.Pointer(&mapOpAttr{
 			mapFd: uint32(m),
-			key:   uint64(uintptr(unsafe.Pointer(&keyValue[0]))),
-			value: uint64(uintptr(unsafe.Pointer(&(*value)[0]))),
+			key:   newPtr(unsafe.Pointer(&keyValue[0])),
+			value: newPtr(unsafe.Pointer(&(*value)[0])),
 		}), 32)
 	if e != 0 {
 		if e == syscall.ENOENT {
@@ -94,7 +94,7 @@ func (m Map) Delete(key encoding.BinaryMarshaler) (bool, error) {
 	_, e := bpfCall(_MapDeleteElem,
 		unsafe.Pointer(&mapOpAttr{
 			mapFd: uint32(m),
-			key:   uint64(uintptr(unsafe.Pointer(&keyValue[0]))),
+			key:   newPtr(unsafe.Pointer(&keyValue[0])),
 		}), 32)
 	if e == 0 {
 		return true, nil
@@ -128,8 +128,8 @@ func (m Map) GetNextKeyRaw(key encoding.BinaryMarshaler, nextKey *[]byte) (bool,
 	_, e := bpfCall(_MapGetNextKey,
 		unsafe.Pointer(&mapOpAttr{
 			mapFd: uint32(m),
-			key:   uint64(uintptr(unsafe.Pointer(&keyValue[0]))),
-			value: uint64(uintptr(unsafe.Pointer(&(*nextKey)[0]))),
+			key:   newPtr(unsafe.Pointer(&keyValue[0])),
+			value: newPtr(unsafe.Pointer(&(*nextKey)[0])),
 		}), 32)
 	if e != 0 {
 		if e == syscall.ENOENT {
@@ -173,8 +173,8 @@ func (m Map) put(key encoding.BinaryMarshaler, value encoding.BinaryMarshaler, p
 	_, e := bpfCall(_MapUpdateElem,
 		unsafe.Pointer(&mapOpAttr{
 			mapFd: uint32(m),
-			key:   uint64(uintptr(unsafe.Pointer(&keyValue[0]))),
-			value: uint64(uintptr(unsafe.Pointer(&v[0]))),
+			key:   newPtr(unsafe.Pointer(&keyValue[0])),
+			value: newPtr(unsafe.Pointer(&v[0])),
 			flags: putType,
 		}), 32)
 	if e != 0 {

--- a/prog.go
+++ b/prog.go
@@ -38,11 +38,11 @@ func NewProgram(progType ProgType, instructions *Instructions, license string, k
 	fd, e := bpfCall(_ProgLoad, unsafe.Pointer(&progCreateAttr{
 		progType:     progType,
 		insCount:     insCount,
-		instructions: uint64(uintptr(unsafe.Pointer(&cInstructions[0]))),
-		license:      uint64(uintptr(unsafe.Pointer(&lic[0]))),
+		instructions: newPtr(unsafe.Pointer(&cInstructions[0])),
+		license:      newPtr(unsafe.Pointer(&lic[0])),
 		logLevel:     1,
 		logSize:      LogBufSize,
-		logBuf:       uint64(uintptr(unsafe.Pointer(&logs[0]))),
+		logBuf:       newPtr(unsafe.Pointer(&logs[0])),
 	}), 48)
 	if e != 0 {
 		if logs[0] != 0 {

--- a/ptr_32_be.go
+++ b/ptr_32_be.go
@@ -1,0 +1,14 @@
+// +build armbe mips mips64p32
+
+package ebpf
+
+import (
+	"unsafe"
+)
+
+// ptr wraps an unsafe.Pointer to be 64bit to
+// conform to the syscall specification.
+type syscallPtr struct {
+	ptr unsafe.Pointer
+	pad uint32
+}

--- a/ptr_32_le.go
+++ b/ptr_32_le.go
@@ -1,0 +1,14 @@
+// +build 386 amd64p32 arm mipsle mips64p32le
+
+package ebpf
+
+import (
+	"unsafe"
+)
+
+// ptr wraps an unsafe.Pointer to be 64bit to
+// conform to the syscall specification.
+type syscallPtr struct {
+	ptr unsafe.Pointer
+	pad uint32
+}

--- a/ptr_64.go
+++ b/ptr_64.go
@@ -1,0 +1,14 @@
+// +build !386,!amd64p32,!arm,!mipsle,!mips64p32le
+// +build !armbe,!mips,!mips64p32
+
+package ebpf
+
+import (
+	"unsafe"
+)
+
+// ptr wraps an unsafe.Pointer to be 64bit to
+// conform to the syscall specification.
+type syscallPtr struct {
+	ptr unsafe.Pointer
+}


### PR DESCRIPTION
When using uintptr(unsafe.Pointer()) we're hiding the fact that we are using a particular piece
of memory from the garbage collector. This can lead to the GC freeing memory that is in use by the
bpf syscall. See https://github.com/golang/go/issues/13372 for context.

The problem arises with the various *Attr structures, which stuff pointers into uint64 values.
While the syscall will keep the reference to *Attr alive, whatever is pointed to by *Attr may
be collected. This can lead to random crashes.

To keep pointers visible to the GC we introduce a new syscallPtr struct. This is required since
the size of unsafe.Pointer is platform dependent, but the syscall interface always expects a 64bit
value.

Note that the current code won't compile on ppc, s390, sparc GOARCH since I couldn't figure out
their endianness.