### PR TITLE
add support for BPF_PROG_TEST_RUN

### DIFF
--- a/cmd/ebpf-test/main.go
+++ b/cmd/ebpf-test/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/nathanjsweet/ebpf"
+)
+
+var bufSize = flag.Int("out", 65536, "Size of output buffer in `bytes`")
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "%s: <elf-file> [prog-name]\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		flag.Usage()
+		os.Exit(42)
+	}
+
+	path := flag.Args()[0]
+	coll, err := ebpf.NewCollectionFromFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't load %s: %v\n", path, err)
+		os.Exit(42)
+	}
+
+	if flag.NArg() == 1 {
+		fmt.Println("Maps:")
+		coll.ForEachMap(func(name string, m ebpf.Map) {
+			fmt.Printf("\t%v\n", name)
+		})
+
+		fmt.Println("Programs:")
+		coll.ForEachProgram(func(name string, _ ebpf.Program) {
+			fmt.Printf("\t%v\n", name)
+		})
+
+		return
+	}
+
+	progName := flag.Args()[1]
+	prog, ok := coll.GetProgramByName(progName)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "%v does not contain program %v\n", path, progName)
+		os.Exit(42)
+	}
+
+	in, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't read stdin: %v\n", err)
+		os.Exit(42)
+	}
+
+	ret, out, err := prog.Test(in, *bufSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't run %v: %v\n", progName, err)
+		os.Exit(42)
+	}
+
+	if out != nil {
+		if _, err := os.Stdout.Write(out); err != nil {
+			fmt.Fprintf(os.Stderr, "Can't write output: %v\n", err)
+			os.Exit(42)
+		}
+	}
+
+	os.Exit(int(ret))
+}

--- a/syscalls.go
+++ b/syscalls.go
@@ -67,6 +67,17 @@ type perfEventAttr struct {
 	padding uint16
 }
 
+type progTestRunAttr struct {
+	fd          uint32
+	retval      uint32
+	dataSizeIn  uint32
+	dataSizeOut uint32
+	dataIn      syscallPtr
+	dataOut     syscallPtr
+	repeat      uint32
+	duration    uint32
+}
+
 func newPtr(ptr unsafe.Pointer) syscallPtr {
 	return syscallPtr{ptr: ptr}
 }

--- a/types.go
+++ b/types.go
@@ -96,7 +96,7 @@ const (
 	_ObjGet
 	// _BPF_PROG_ATTACH
 	// _BPF_PROG_DETACH
-	// _BPF_PROG_TEST_RUN
+	_ProgTestRun = 10
 	// _BPF_PROG_GET_NEXT_ID
 	// _BPF_MAP_GET_NEXT_ID
 	// _BPF_PROG_GET_FD_BY_ID


### PR DESCRIPTION
This adds support to test and benchmark eBPF programs using the BPF_PROG_TEST_RUN command
which was added in Linux 4.12.